### PR TITLE
fix: should export ContextDelegation and Context both

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -11,9 +11,9 @@ import onFinished from 'on-finished';
 import statuses from 'statuses';
 import compose from 'koa-compose';
 import { HttpError } from 'http-errors';
-import Context from './context.js';
-import Request from './request.js';
-import Response from './response.js';
+import { Context } from './context.js';
+import { Request } from './request.js';
+import { Response } from './response.js';
 import type { ContextDelegation } from './context.js';
 import type { CustomError, AnyProto } from './types.js';
 
@@ -22,7 +22,6 @@ const debug = debuglog('koa:application');
 export type ProtoImplClass<T = object> = new(...args: any[]) => T;
 export type Next = () => Promise<void>;
 export type MiddlewareFunc = (ctx: ContextDelegation, next: Next) => Promise<void> | void;
-export type { ContextDelegation as Context } from './context.js';
 
 /**
  * Expose `Application` class.
@@ -44,7 +43,7 @@ export class Application extends Emitter {
   middleware: MiddlewareFunc[];
   ctxStorage: AsyncLocalStorage<ContextDelegation>;
   silent: boolean;
-  ContextClass: ProtoImplClass<Context>;
+  ContextClass: ProtoImplClass<ContextDelegation>;
   context: AnyProto;
   RequestClass: ProtoImplClass<Request>;
   request: AnyProto;
@@ -82,7 +81,7 @@ export class Application extends Emitter {
     this.middleware = [];
     this.ctxStorage = getAsyncLocalStorage();
     this.silent = false;
-    this.ContextClass = class ApplicationContext extends Context {};
+    this.ContextClass = class ApplicationContext extends Context {} as any;
     this.context = this.ContextClass.prototype;
     this.RequestClass = class ApplicationRequest extends Request {};
     this.request = this.RequestClass.prototype;

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,12 +5,12 @@ import httpAssert from 'http-assert';
 import delegate from 'delegates';
 import statuses from 'statuses';
 import Cookies from 'cookies';
-import type Application from './application.js';
-import type Request from './request.js';
-import type Response from './response.js';
+import type { Application } from './application.js';
+import type { Request } from './request.js';
+import type { Response } from './response.js';
 import type { CustomError, AnyProto } from './types.js';
 
-export default class Context {
+export class Context {
   app: Application;
   req: IncomingMessage;
   res: ServerResponse;

--- a/src/request.ts
+++ b/src/request.ts
@@ -10,19 +10,19 @@ import contentType from 'content-type';
 import parse from 'parseurl';
 import typeis from 'type-is';
 import fresh from 'fresh';
-import type Application from './application.js';
-import type Context from './context.js';
-import type Response from './response.js';
+import type { Application } from './application.js';
+import type { ContextDelegation } from './context.js';
+import type { Response } from './response.js';
 
-export default class Request {
+export class Request {
   app: Application;
   req: IncomingMessage;
   res: ServerResponse;
-  ctx: Context;
+  ctx: ContextDelegation;
   response: Response;
   originalUrl: string;
 
-  constructor(app: Application, ctx: Context, req: IncomingMessage, res: ServerResponse) {
+  constructor(app: Application, ctx: ContextDelegation, req: IncomingMessage, res: ServerResponse) {
     this.app = app;
     this.req = req;
     this.res = res;

--- a/src/response.ts
+++ b/src/response.ts
@@ -12,11 +12,11 @@ import statuses from 'statuses';
 import destroy from 'destroy';
 import vary from 'vary';
 import encodeUrl from 'encodeurl';
-import type Application from './application.js';
+import type { Application } from './application.js';
 import type { ContextDelegation } from './context.js';
-import type Request from './request.js';
+import type { Request } from './request.js';
 
-export default class Response {
+export class Response {
   app: Application;
   req: IncomingMessage;
   res: ServerResponse;

--- a/test/application.test-d.ts
+++ b/test/application.test-d.ts
@@ -1,11 +1,11 @@
 import { expectType } from 'tsd';
-import { Context } from '../src/index.js';
+import { ContextDelegation } from '../src/index.js';
 import Application from '../src/application.js';
 
-const ctx = {} as Context;
+const ctx = {} as ContextDelegation;
 expectType<string>(ctx.ip);
 expectType<Application>(ctx.app);
 
 const app = {} as Application;
 expectType<string>(app.env);
-expectType<Context | undefined>(app.ctxStorage.getStore());
+expectType<ContextDelegation | undefined>(app.ctxStorage.getStore());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated import statements across various modules to use ES6 destructuring syntax.
  - Renamed `Context` to `ContextDelegation` for better clarity and consistency.
  - Changed class declarations from default exports to named exports.

These changes help in improving code readability and maintainability but don't impact the end-user experience directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->