### PR TITLE
fix: make Context state property can be override by Sub Class

### DIFF
--- a/example/extend/Context.ts
+++ b/example/extend/Context.ts
@@ -1,0 +1,7 @@
+import { Context } from '../../src/index.js';
+
+export class CustomContext extends Context {
+  get state() {
+    return { foo: 'bar' };
+  }
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -17,15 +17,14 @@ export class Context {
   res: ServerResponse;
   request: Request & AnyProto;
   response: Response & AnyProto;
-  state: Record<string, any>;
   originalUrl: string;
   respond?: boolean;
+  #state: Record<string, any> = {};
 
   constructor(app: Application, req: IncomingMessage, res: ServerResponse) {
     this.app = app;
     this.req = req;
     this.res = res;
-    this.state = {};
     this.request = new app.RequestClass(app, this, req, res);
     this.response = new app.ResponseClass(app, this as any, req, res);
     this.request.response = this.response;
@@ -218,6 +217,10 @@ export class Context {
 
   set cookies(cookies: Cookies) {
     this._cookies = cookies;
+  }
+
+  get state() {
+    return this.#state;
   }
 }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -12,6 +12,10 @@ import type { Application } from './application.js';
 import type { ContextDelegation } from './context.js';
 import type { Response } from './response.js';
 
+export interface RequestSocket extends Socket {
+  encrypted: boolean;
+}
+
 export class Request {
   [key: symbol]: unknown;
   app: Application;
@@ -299,7 +303,7 @@ export class Request {
    * Return the request socket.
    */
   get socket() {
-    return this.req.socket as (Socket & { encrypted: boolean; });
+    return this.req.socket as RequestSocket;
   }
 
   /**

--- a/test/application/index.test.ts
+++ b/test/application/index.test.ts
@@ -117,4 +117,15 @@ describe('app', () => {
       throw CreateError(500, 'test error');
     }, Koa.HttpError);
   });
+
+  it('should print object work', () => {
+    const app = new Koa();
+    const ctx = (app as any).createContext({} as any, {
+      getHeaders() {},
+    } as any);
+    console.log(ctx.request);
+    console.log(ctx.response);
+    console.log(ctx.context);
+    console.log(app);
+  });
 });

--- a/test/context/state.test.ts
+++ b/test/context/state.test.ts
@@ -8,6 +8,35 @@ describe('ctx.state', () => {
 
     app.use(ctx => {
       assert.deepStrictEqual(ctx.state, {});
+      ctx.state.user = 'example';
+    });
+
+    app.use(ctx => {
+      assert.deepStrictEqual(ctx.state, { user: 'example' });
+    });
+
+    const server = app.listen();
+
+    return request(server)
+      .get('/')
+      .expect(404);
+  });
+
+  it('should override state getter', () => {
+    const app = new Koa();
+    app.ContextClass = class extends app.ContextClass {
+      get state(): Record<string, string> {
+        return { foo: 'bar' };
+      }
+    };
+
+    app.use(ctx => {
+      assert.deepStrictEqual(ctx.state, { foo: 'bar' });
+      (ctx.state as any).user = 'example';
+    });
+
+    app.use(ctx => {
+      assert.deepStrictEqual(ctx.state, { foo: 'bar' });
     });
 
     const server = app.listen();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `CustomContext` class for enhanced state management.
	- Added a new `RequestSocket` interface to simplify socket type definitions.

- **Bug Fixes**
	- Improved error handling in the `Context` class.

- **Tests**
	- Added new test cases for `ctx.state` functionality and Koa application context logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->