### PR TITLE
fix: avoid redos on host and protocol getter

### DIFF
--- a/example/extend/Request.ts
+++ b/example/extend/Request.ts
@@ -17,7 +17,7 @@ export class CustomRequest extends Request {
       this[HOST] = '';
       return '';
     }
-    this[HOST] = rawHost.split(/\s*,\s*/)[0];
+    this[HOST] = rawHost.split(/,/)[0].trim();
     return host;
   }
 }

--- a/src/response.ts
+++ b/src/response.ts
@@ -125,7 +125,7 @@ export class Response {
 
     // string
     if (typeof val === 'string') {
-      if (setType) this.type = /^\s*</.test(val) ? 'html' : 'text';
+      if (setType) this.type = /^\s*?</.test(val) ? 'html' : 'text';
       this.length = Buffer.byteLength(val);
       return;
     }

--- a/test/request/host.test.ts
+++ b/test/request/host.test.ts
@@ -89,6 +89,34 @@ describe('req.host', () => {
         req.header.host = 'bar.com:8000';
         assert.strictEqual(req.host, 'proxy.com:8080');
       });
+
+      it('should fallback to host header when x-forwarded-host is invalid', () => {
+        // h1
+        let req = request();
+        req.app.proxy = true;
+        req.header['x-forwarded-host'] = '  ,    ';
+        req.header.host = 'foo.com';
+        assert.strictEqual(req.host, 'foo.com');
+
+        // h2
+        req = request({
+          httpVersionMajor: 2,
+          httpVersion: '2.0',
+        });
+        req.app.proxy = true;
+        req.header['x-forwarded-host'] = '  ,    ';
+        req.header[':authority'] = 'foo.com:3000';
+        assert.strictEqual(req.host, 'foo.com:3000');
+
+        // no host and no authority
+        req = request({
+          httpVersionMajor: 2,
+          httpVersion: '2.0',
+        });
+        req.app.proxy = true;
+        req.header['x-forwarded-host'] = '  ,    ';
+        assert.strictEqual(req.host, '');
+      });
     });
   });
 });

--- a/test/request/ips.test.ts
+++ b/test/request/ips.test.ts
@@ -14,10 +14,22 @@ describe('req.ips', () => {
 
     describe('and proxy is trusted', () => {
       it('should be used', () => {
-        const req = request();
+        let req = request();
         req.app.proxy = true;
         req.header['x-forwarded-for'] = '127.0.0.1,127.0.0.2';
         assert.deepStrictEqual(req.ips, [ '127.0.0.1', '127.0.0.2' ]);
+
+        req = request();
+        req.app.proxy = true;
+        req.header['x-forwarded-for'] = '127.0.0.1,  ,  ,,,,127.0.0.2';
+        assert.deepStrictEqual(req.ips, [ '127.0.0.1', '127.0.0.2' ]);
+      });
+
+      it('should ignore invalid ips', () => {
+        const req = request();
+        req.app.proxy = true;
+        req.header['x-forwarded-for'] = ',  ,  ,,,,   , ,,,  ,';
+        assert.deepStrictEqual(req.ips, []);
       });
     });
   });

--- a/test/response/body.test.ts
+++ b/test/response/body.test.ts
@@ -79,7 +79,7 @@ describe('res.body=', () => {
     describe('when it contains leading whitespace', () => {
       it('should default to html', () => {
         const res = response();
-        res.body = '    <h1>Tobi</h1>';
+        res.body = ' '.repeat(10000000) + '\t\r\n<h1>Tobi</h1>';
         assert.strictEqual('text/html; charset=utf-8', res.header['content-type']);
       });
     });


### PR DESCRIPTION
https://github.com/koajs/koa/security/advisories/GHSA-593f-38f6-jp5m

pick from https://github.com/koajs/koa/commit/5f294bb1c7c8d9c61904378d250439a321bffd32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing of header values by trimming extraneous spaces, ensuring accurate extraction of host, protocol, and IP information.
  - Enhanced HTML content detection in responses to assign the correct content type even when additional whitespace is present.

- **Refactor**
  - Streamlined the handling of comma-separated header values for consistency across request and response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->