### PR TITLE
test: add Node.js 24

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,6 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
-      version: '18.19.0, 18, 20, 22, 23'
+      version: '18.19.0, 18, 20, 22, 24'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -77,6 +77,7 @@
     "import/export": "error",
     "import/no-default-export": "allow",
     "import/unambiguous": "error",
+    "import/group-exports": "allow",
 
     // promise
     "promise/no-return-wrap": "error",

--- a/src/response.ts
+++ b/src/response.ts
@@ -75,8 +75,8 @@ export class Response {
    */
   set status(code: number) {
     if (this.headerSent) return;
-    assert(Number.isInteger(code), 'status code must be a number');
-    assert(code >= 100 && code <= 999, `invalid status code: ${code}`);
+    assert.ok(Number.isInteger(code), 'status code must be a number');
+    assert.ok(code >= 100 && code <= 999, `invalid status code: ${code}`);
     this._explicitStatus = true;
     this.res.statusCode = code;
     if (this.req.httpVersionMajor < 2 && statuses.message[code]) {

--- a/test/application/currentContext.test.ts
+++ b/test/application/currentContext.test.ts
@@ -26,7 +26,7 @@ describe('app.currentContext', () => {
         });
       });
       assert.equal(ctx, app.currentContext);
-      assert(app.currentContext);
+      assert.ok(app.currentContext);
       app.currentContext.body = 'ok';
     });
 

--- a/test/application/respond.test.ts
+++ b/test/application/respond.test.ts
@@ -53,7 +53,7 @@ describe('app.respond', () => {
         .expect(200)
         .expect('lol')
         .expect(res => {
-          assert(!res.headers.foo);
+          assert.ok(!res.headers.foo);
         });
     });
 
@@ -108,7 +108,7 @@ describe('app.respond', () => {
 
       assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
       assert.equal(res.headers['content-length'], '5');
-      assert(!res.text);
+      assert.ok(!res.text);
     });
 
     it('should keep json headers', async () => {
@@ -127,7 +127,7 @@ describe('app.respond', () => {
         'application/json; charset=utf-8'
       );
       assert.equal(res.headers['content-length'], '17');
-      assert(!res.text);
+      assert.ok(!res.text);
     });
 
     it('should keep string headers', async () => {
@@ -143,7 +143,7 @@ describe('app.respond', () => {
 
       assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
       assert.equal(res.headers['content-length'], '11');
-      assert(!res.text);
+      assert.ok(!res.text);
     });
 
     it('should keep buffer headers', async () => {
@@ -159,7 +159,7 @@ describe('app.respond', () => {
 
       assert.equal(res.headers['content-type'], 'application/octet-stream');
       assert.equal(res.headers['content-length'], '11');
-      assert(!res.text);
+      assert.ok(!res.text);
     });
 
     it('should keep stream header if set manually', async () => {
@@ -177,7 +177,7 @@ describe('app.respond', () => {
       const res = await request(server).head('/').expect(200);
 
       assert.equal(Number.parseInt(res.header['content-length']), length);
-      assert(!res.text);
+      assert.ok(!res.text);
     });
 
     it('should respond with a 404 if no body was set', () => {
@@ -353,7 +353,7 @@ describe('app.respond', () => {
           .expect('custom status');
 
         assert.equal(res.statusCode, 700);
-        assert((res as unknown as { res: { statusMessage: string } }).res);
+        assert.ok((res as unknown as { res: { statusMessage: string } }).res);
         assert.equal(
           (res as unknown as { res: { statusMessage: string } }).res
             .statusMessage,
@@ -376,7 +376,7 @@ describe('app.respond', () => {
         const res = await request(server).get('/').expect(200).expect('ok');
 
         assert.equal(res.statusCode, 200);
-        assert((res as unknown as { res: { statusMessage: string } }).res);
+        assert.ok((res as unknown as { res: { statusMessage: string } }).res);
         assert.equal(
           (res as unknown as { res: { statusMessage: string } }).res
             .statusMessage,
@@ -721,13 +721,17 @@ describe('app.respond', () => {
 
       app.use((ctx, next) => {
         // oxlint-disable-next-line promise/prefer-await-to-then
-        return next()
-          .then(() => {
-            ctx.body = 'Hello';
-          })
-          .catch(() => {
-            ctx.body = 'Got error';
-          });
+        return (
+          next()
+            // oxlint-disable-next-line promise/prefer-await-to-then
+            .then(() => {
+              ctx.body = 'Hello';
+            })
+            // oxlint-disable-next-line promise/prefer-await-to-then
+            .catch(() => {
+              ctx.body = 'Got error';
+            })
+        );
       });
 
       app.use(() => {

--- a/test/application/use.test.ts
+++ b/test/application/use.test.ts
@@ -95,7 +95,7 @@ describe('app.use(fn)', () => {
         } as unknown as MiddlewareFunc);
       },
       err => {
-        assert(err instanceof TypeError);
+        assert.ok(err instanceof TypeError);
         assert.match(err.message, /Support for generators was removed/);
         return true;
       }
@@ -123,7 +123,7 @@ describe('app.use(fn)', () => {
         } as unknown as MiddlewareFunc);
       },
       err => {
-        assert(err instanceof TypeError);
+        assert.ok(err instanceof TypeError);
         assert.match(err.message, /Support for generators was removed/);
         return true;
       }

--- a/test/context/cookies.test.ts
+++ b/test/context/cookies.test.ts
@@ -34,7 +34,7 @@ describe('ctx.cookies', () => {
           try {
             ctx.cookies.set('foo', 'bar', { signed: true });
           } catch (err) {
-            assert(err instanceof Error);
+            assert.ok(err instanceof Error);
             ctx.body = err.message;
           }
         });

--- a/test/request/accept.test.ts
+++ b/test/request/accept.test.ts
@@ -7,7 +7,7 @@ describe('ctx.accept', () => {
     const ctx = context();
     ctx.req.headers.accept =
       'application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain';
-    assert(ctx.accept instanceof Accept);
+    assert.ok(ctx.accept instanceof Accept);
   });
 });
 

--- a/test/request/inspect.test.ts
+++ b/test/request/inspect.test.ts
@@ -9,8 +9,8 @@ describe('req.inspect()', () => {
       const request = context().request;
       request.method = 'GET';
       delete (request as unknown as { req: unknown }).req;
-      assert(undefined === request.inspect());
-      assert(util.inspect(request) === 'undefined');
+      assert.ok(undefined === request.inspect());
+      assert.ok(util.inspect(request) === 'undefined');
     });
   });
 

--- a/test/request/query.test.ts
+++ b/test/request/query.test.ts
@@ -5,7 +5,7 @@ describe('ctx.query', () => {
   describe('when missing', () => {
     it('should return an empty object', () => {
       const ctx = context({ url: '/' });
-      assert(Object.keys(ctx.query).length === 0);
+      assert.ok(Object.keys(ctx.query).length === 0);
     });
 
     it("should return the same object each time it's accessed", () => {

--- a/test/request/whatwg-url.test.ts
+++ b/test/request/whatwg-url.test.ts
@@ -5,14 +5,14 @@ import { request } from '../test-helpers/context.js';
 describe('req.URL', () => {
   it('should not throw when host is void', () => {
     // Accessing the URL should not throw.
-    assert(request().URL);
+    assert.ok(request().URL);
   });
 
   it('should not throw when header.host is invalid', () => {
     const req = request();
     req.header.host = 'invalid host';
     // Accessing the URL should not throw.
-    assert(req.URL);
+    assert.ok(req.URL);
   });
 
   it('should return empty object when invalid', () => {

--- a/test/response/flushHeaders.test.ts
+++ b/test/response/flushHeaders.test.ts
@@ -135,7 +135,7 @@ describe('ctx.flushHeaders()', () => {
   it('should catch stream error', done => {
     const app = new Koa();
     app.once('error', err => {
-      assert(err.message === 'mock error');
+      assert.ok(err.message === 'mock error');
       done();
     });
 

--- a/test/response/status.test.ts
+++ b/test/response/status.test.ts
@@ -51,7 +51,7 @@ describe('res.status=', () => {
           httpVersion: '2.0',
         });
         res.status = 200;
-        assert(!res.res.statusMessage);
+        assert.ok(!res.res.statusMessage);
       });
     });
   });

--- a/test/response/type.test.ts
+++ b/test/response/type.test.ts
@@ -54,8 +54,8 @@ describe('ctx.type=', () => {
     it('should not set a content-type', () => {
       const ctx = context();
       ctx.type = 'asdf';
-      assert(!ctx.type);
-      assert(!ctx.response.header['content-type']);
+      assert.ok(!ctx.type);
+      assert.ok(!ctx.response.header['content-type']);
     });
   });
 });
@@ -64,7 +64,7 @@ describe('ctx.type', () => {
   describe('with no Content-Type', () => {
     it('should return ""', () => {
       const ctx = context();
-      assert(!ctx.type);
+      assert.ok(!ctx.type);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Node.js versions used in continuous integration testing to include version 24 instead of 23.
  - Improved test reliability and clarity by refining assertion methods across multiple test suites.
  - Enhanced linting configuration to allow grouped exports in import statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->